### PR TITLE
Updated the image script to create one for the organization. Now public.

### DIFF
--- a/Cadence/package.json
+++ b/Cadence/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "node cadence.js",
     "start": "NODE_ENV=production node cadence.js",
-    "image": "docker build -t cadence . --no-cache"
+    "image": "docker build -t shadowit/cadence . --no-cache"
   },
   "author": "Avery Lindley <develop.lindley@gmail.com>",
   "license": "ISC",

--- a/Commuter/package.json
+++ b/Commuter/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"dev": "node commuter.js",
 		"start": "NODE_ENV=production node commuter.js",
-		"image": "docker build -t commuter . --no-cache"
+		"image": "docker build -t shadowit/commuter . --no-cache"
 	},
 	"author": "Avery Lindley <Develop.lindley@gmail.com>",
 	"license": "ISC",

--- a/Docker-compose.yml
+++ b/Docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - "6380:6379"
 
   cadence:
-    image: cadence
+    image: shadowit/cadence
     ports:
       - "3002:3002"
     deploy:
@@ -30,7 +30,7 @@ services:
       - subscription
 
   history:
-    image: history
+    image: shadowit/history
     deploy:
       replicas: 1
       restart_policy:
@@ -41,7 +41,7 @@ services:
       - redis-status
 
   subscription:
-    image: subscription
+    image: shadowit/subscription
     ports:
       - "3003:3003"
     deploy:
@@ -52,7 +52,7 @@ services:
       - redis-subscription
 
   commuter:
-    image: commuter
+    image: shadowit/commuter
     ports:
       - "3004:3004"
     deploy:
@@ -65,7 +65,7 @@ services:
       - cadence
 
   monitor:
-    image: monitor
+    image: shadowit/monitor
     ports:
       - "3000:3000"
     deploy:

--- a/History/package.json
+++ b/History/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "node server.js",
     "start": "NODE_ENV=production node server.js",
-		"image": "docker build -t history . --no-cache"
+		"image": "docker build -t shadowit/history . --no-cache"
   },
   "author": "Avery Lindley <develop.lindley@gmail.com>",
   "license": "ISC",

--- a/Monitor/package.json
+++ b/Monitor/package.json
@@ -7,7 +7,7 @@
     "dev": "next",
     "build": "next build",
     "start": "next start",
-    "image": "docker build -t monitor ."
+    "image": "docker build -t shadowit/monitor . --no-cache"
   },
   "author": "Avery Lindley <Develop.lindley@gmail.com>",
   "license": "ISC",

--- a/Subscription/package.json
+++ b/Subscription/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "node server.js",
     "start": "NODE_ENV=production node server.js",
-    "image": "docker build -t subscription . --no-cache"
+    "image": "docker build -t shadowit/subscription . --no-cache"
   },
   "author": "Avery Lindley <develop.lindley@gmail.com>",
   "license": "ISC",


### PR DESCRIPTION
## Done
- Added the organization prefix to each image and created registry for each.

Here is the hub. You **don't** need to create a docker hub account, but I would anyway! You cannot push to it unless you have one, but you can pull.
- https://hub.docker.com/u/shadowit/dashboard/

## TODO
- Add descriptions for each, and start the image versioning.
- Now that were not just messing with local:latest images, versions are needed!
- Maybe leverage NPM versioning to automatically update the version # on the _npm run image_ script?
